### PR TITLE
Fix: Fixed bug causing sidebar to not toggle

### DIFF
--- a/q2a-sticky-sidebar/sticky-sidebar-layer.php
+++ b/q2a-sticky-sidebar/sticky-sidebar-layer.php
@@ -19,8 +19,7 @@ function footer()
 			$this->output(
 				
 				"<script type='text/javascript' src='".QA_HTML_THEME_LAYER_URLTOROOT."sticky-sidebar.js'></script>",
-				"<script type='text/javascript'>if ($(window).width() > ".$screen_width.") {var sidebar = new StickySidebar('".$sidebar_selector."', {containerSelector: '".$parent_selector."',innerWrapperSelector: '".$inner_selector."',topSpacing: ".$top_spacing.",bottomSpacing: ".$bottom_spacing."});}</script>"
-				
+                		"<script type='text/javascript'>if ($(window).width() > " . $screen_width . ") {var sidebar = new StickySidebar('" . $sidebar_selector . "', {containerSelector: '" . $parent_selector . "',innerWrapperSelector: '" . $inner_selector . "',topSpacing: " . $top_spacing . ",bottomSpacing: " . $bottom_spacing . ", minWidth: ". $screen_width . "});}</script>"				
 			);			
 		}
 		qa_html_theme_base::footer();


### PR DESCRIPTION
Sidebar script would not toggle on/off if the screen is resized to be wider/narrower than the default 980 pixels.